### PR TITLE
Added comment on "env" key

### DIFF
--- a/PyTest.sublime-settings
+++ b/PyTest.sublime-settings
@@ -32,6 +32,8 @@
 
     "file_regex": "^(.*):([0-9]+):(.)([\\w ]*)$",
 
+    // Set environment variables here if needed
+    // e.g. {"LC_ALL":"C.utf-8", "LANG":"C.utf-8"}
     "env" : {}
 
 }

--- a/PyTest.sublime-settings
+++ b/PyTest.sublime-settings
@@ -33,7 +33,7 @@
     "file_regex": "^(.*):([0-9]+):(.)([\\w ]*)$",
 
     // Set environment variables here if needed
-    // e.g. {"LC_ALL":"C.utf-8", "LANG":"C.utf-8"}
+    // e.g. {"LC_ALL":"en_US.utf-8", "LANG":"en_US.utf-8"}
     "env" : {}
 
 }


### PR DESCRIPTION
Description of use of "env" key for setting environment variables, with an example
I had trouble finding this setting to solve a problem with Click, so I added a small description