### PR TITLE
default working dir to folder

### DIFF
--- a/PyTest.sublime-settings
+++ b/PyTest.sublime-settings
@@ -10,7 +10,7 @@
 
     // Usually your project_path (which is the first folder in your project
     // settings)
-    "working_dir": "${project_path}",
+    "working_dir": "${folder}",
 
     // Where your tests are located, often you can leave this blank because
     // pytest will find your tests anyway. Otherwise usually below the


### PR DESCRIPTION
change the default folder to correspond to the description :

// Usually your project_path (which is the first folder in your project
    // settings)

with `"working_dir": "${project_path}"`  pytest can't find test files if sublime-project is stored in another directory