### PR TITLE
allow multiargs for pytest

### DIFF
--- a/PyTest.py
+++ b/PyTest.py
@@ -160,7 +160,7 @@ class PytestRunCommand(sublime_plugin.WindowCommand):
 
         return {
             "file_regex": kwargs['file_regex'],
-            "cmd": [kwargs['pytest']] + options + target,
+            "cmd": kwargs['pytest'].split() + options + target,
             "working_dir": kwargs['working_dir'],
             "quiet": True,
             "env": kwargs['env']


### PR DESCRIPTION
This change allow to use a command line instead of only one executable.

It's needed if you are ussing something like pipenv or poetry to run your tests.
Instead of setting :`"pytest": "/my/long/and/complicated/path/to/virtualenv/bin/pytest"` I can now use `"pytest": "poetry run pytest"`