### PR TITLE
Set `junit_family=xunit2`

### DIFF
--- a/pytest_exec.py
+++ b/pytest_exec.py
@@ -50,7 +50,7 @@ class PytestExecCommand(exec.ExecCommand):
             'cmd': kw['cmd']
         })
 
-        super(PytestExecCommand, self).run(**kw)
+        super().run(**kw)
 
         # output_view cannot be dumped through broadcast,
         # so we go the ugly mile
@@ -58,7 +58,7 @@ class PytestExecCommand(exec.ExecCommand):
         PyTest.State['pytest_view'] = self.output_view
 
     def finish(self, proc):
-        super(PytestExecCommand, self).finish(proc)
+        super().finish(proc)
 
         view = self.output_view
         output = get_whole_text(view).strip()

--- a/pytest_exec.py
+++ b/pytest_exec.py
@@ -40,7 +40,10 @@ class PytestExecCommand(exec.ExecCommand):
         # Note that if the user already wants a xml-report, he has bad luck,
         # bc the last `--junit-xml` wins.
         if mode != 'line':
-            kw['cmd'] += ['--junit-xml={}'.format(get_report_file())]
+            kw['cmd'] += [
+                '--junit-xml={}'.format(get_report_file()),
+                '-o', 'junit_family=xunit2'
+            ]
 
         broadcast('pytest_start', {
             'mode': mode,


### PR DESCRIPTION
As suggested in https://github.com/kaste/PyTest/issues/25#issuecomment-559883475
we can pass arbitrary options on the CLI using the `-o` arg.

Fixes #25 