### PR TITLE
Diagnose/resolve ST4 flash status bar (#28)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# pyenv
+.python-version
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+.pytest_cache
+nosetests.xml
+coverage.xml
+
+# OSX metafiles
+.DS_Store

--- a/PyTest.py
+++ b/PyTest.py
@@ -18,8 +18,10 @@ OUTPUT_PANEL = 'output.exec'
 
 
 def plugin_loaded():
+    print("Checking apply_theme_tweaks")
     if Settings.get('apply_theme_tweaks', False):
         util.tweak_theme()
+        print("TWEAKED THEME")
 
 
 class PytestAutoRunCommand(sublime_plugin.WindowCommand):
@@ -119,6 +121,7 @@ class PytestRunCommand(sublime_plugin.WindowCommand):
         })
 
         args = self.make_args(kwargs)
+        print("TRYING TO PING")
         show_status_ping()
 
         # This is not universal, but a Win32 interpretation. Seems like Python
@@ -267,6 +270,7 @@ class PytestStart(sublime_plugin.WindowCommand):
 
 class PytestFinished(sublime_plugin.WindowCommand):
     def run(self, summary, failures):
+        print("Pytest Finished")
         State.update({
             'summary': summary,
             'failures': failures,
@@ -275,6 +279,7 @@ class PytestFinished(sublime_plugin.WindowCommand):
 
         sublime.set_timeout(lambda: sublime.status_message(summary))
         if not failures:
+            print("FLASHING: GREEN")
             flash_status_bar('pytest_is_green', 500)
 
 
@@ -342,9 +347,12 @@ class PytestStillRunning(sublime_plugin.WindowCommand):
 
 def flash_status_bar(flag, ms=1500):
     settings = sublime.load_settings('Preferences.sublime-settings')
+    print("FLASHING: " + flag)
     settings.set(flag, True)
+    print("FLASHED: " + flag)
 
     sublime.set_timeout(lambda: settings.erase(flag), ms)
+    print("SET TIMEOUT: " + flag)
 
 
 def alive_indicator():

--- a/PyTest.py
+++ b/PyTest.py
@@ -18,10 +18,8 @@ OUTPUT_PANEL = 'output.exec'
 
 
 def plugin_loaded():
-    print("Checking apply_theme_tweaks")
     if Settings.get('apply_theme_tweaks', False):
         util.tweak_theme()
-        print("TWEAKED THEME")
 
 
 class PytestAutoRunCommand(sublime_plugin.WindowCommand):
@@ -121,7 +119,6 @@ class PytestRunCommand(sublime_plugin.WindowCommand):
         })
 
         args = self.make_args(kwargs)
-        print("TRYING TO PING")
         show_status_ping()
 
         # This is not universal, but a Win32 interpretation. Seems like Python
@@ -270,7 +267,6 @@ class PytestStart(sublime_plugin.WindowCommand):
 
 class PytestFinished(sublime_plugin.WindowCommand):
     def run(self, summary, failures):
-        print("Pytest Finished")
         State.update({
             'summary': summary,
             'failures': failures,
@@ -279,7 +275,6 @@ class PytestFinished(sublime_plugin.WindowCommand):
 
         sublime.set_timeout(lambda: sublime.status_message(summary))
         if not failures:
-            print("FLASHING: GREEN")
             flash_status_bar('pytest_is_green', 500)
 
 
@@ -347,12 +342,9 @@ class PytestStillRunning(sublime_plugin.WindowCommand):
 
 def flash_status_bar(flag, ms=1500):
     settings = sublime.load_settings('Preferences.sublime-settings')
-    print("FLASHING: " + flag)
     settings.set(flag, True)
-    print("FLASHED: " + flag)
 
     sublime.set_timeout(lambda: settings.erase(flag), ms)
-    print("SET TIMEOUT: " + flag)
 
 
 def alive_indicator():

--- a/pytest_exec.py
+++ b/pytest_exec.py
@@ -35,7 +35,6 @@ def get_report_file():
 class PytestExecCommand(exec.ExecCommand):
     def run(self, **kw):
         mode = self._tb_mode = get_trace_back_mode(kw['cmd'])
-        print("INSIDE Pytest Exec: START run")
 
         # For the line mode, we don't get useful reports at all.
         # Note that if the user already wants a xml-report, he has bad luck,
@@ -51,22 +50,14 @@ class PytestExecCommand(exec.ExecCommand):
             'cmd': kw['cmd']
         })
 
-        print("INSIDE Pytest Exec: BEFORE super run")
-        print("INSIDE Pytest Exec: self.proc is " + str(self.proc))
         super().run(**kw)
-        print("INSIDE Pytest Exec: self.proc is " + str(self.proc))
-        print("INSIDE Pytest Exec: AFTER super run")
 
         # output_view cannot be dumped through broadcast,
         # so we go the ugly mile
         from . import PyTest
         PyTest.State['pytest_view'] = self.output_view
-        self.finish(self.proc)
-        print("INSIDE Pytest Exec: FINISH run")
 
-    def finish(self, proc):
-        # super().finish(proc)
-        print("INSIDE Pytest Exec: START finish")
+    def on_finished(self, proc):
 
         view = self.output_view
         output = get_whole_text(view).strip()
@@ -104,7 +95,6 @@ class PytestExecCommand(exec.ExecCommand):
             sublime.set_timeout_async(
                 functools.partial(
                     parse_result, base_dir, Matchers[self._tb_mode]))
-        print("INSIDE Pytest Exec: FINISH finish")
 
     def service_text_queue(self):
         self.text_queue_lock.acquire()

--- a/pytest_exec.py
+++ b/pytest_exec.py
@@ -35,6 +35,7 @@ def get_report_file():
 class PytestExecCommand(exec.ExecCommand):
     def run(self, **kw):
         mode = self._tb_mode = get_trace_back_mode(kw['cmd'])
+        print("INSIDE Pytest Exec: START run")
 
         # For the line mode, we don't get useful reports at all.
         # Note that if the user already wants a xml-report, he has bad luck,
@@ -50,15 +51,22 @@ class PytestExecCommand(exec.ExecCommand):
             'cmd': kw['cmd']
         })
 
+        print("INSIDE Pytest Exec: BEFORE super run")
+        print("INSIDE Pytest Exec: self.proc is " + str(self.proc))
         super().run(**kw)
+        print("INSIDE Pytest Exec: self.proc is " + str(self.proc))
+        print("INSIDE Pytest Exec: AFTER super run")
 
         # output_view cannot be dumped through broadcast,
         # so we go the ugly mile
         from . import PyTest
         PyTest.State['pytest_view'] = self.output_view
+        self.finish(self.proc)
+        print("INSIDE Pytest Exec: FINISH run")
 
     def finish(self, proc):
-        super().finish(proc)
+        # super().finish(proc)
+        print("INSIDE Pytest Exec: START finish")
 
         view = self.output_view
         output = get_whole_text(view).strip()
@@ -96,6 +104,7 @@ class PytestExecCommand(exec.ExecCommand):
             sublime.set_timeout_async(
                 functools.partial(
                     parse_result, base_dir, Matchers[self._tb_mode]))
+        print("INSIDE Pytest Exec: FINISH finish")
 
     def service_text_queue(self):
         self.text_queue_lock.acquire()


### PR DESCRIPTION
## Diagnosis

It seems that "something" _used_ to call `PytestExecCommand.finish()`, which no longer does:

[PackageResourceViewer](https://packagecontrol.io/packages/PackageResourceViewer)'s "Open Resource" allowed some low-tech hacking with print stmts in the console, which comprise the first commit of this PR.

```py
git: located Sublime Merge installed at /Applications/Sublime Merge.app
git: using configuration from system git install
git: tracking working dir /Users/jlent/dev/
... <SNIP> ...
git: tracking working dir /Users/jlent/dev/jl_pytest
environment variables loaded using: /bin/zsh -l (21 skipped due to non-utf8 data)
reloading python 3.3 plugin 0_package_control_loader.00-package_control
... <SNIP> ...
reloading python 3.3 plugin Python Flake8 Lint.color_theme
reloading python 3.3 plugin Python Flake8 Lint.Flake8Lint
reloading python 3.3 plugin Python Flake8 Lint.lint
plugins loaded
Checking apply_theme_tweaks
TWEAKED THEME
Lint tools versions:
- Python Flake8 Lint: 2.4.3
- pep8: 1.7.0
- flake8: 2.5.2
- pyflakes: 1.0.0
- mccabe: 0.4.0
- pydocstyle: 1.0.0
- naming: 0.3.3
- debugger: 1.4.0
- import-order: 0.6.1
Package Control: No updated packages
TRYING TO PING
Run /Users/jlent/.pyenv/shims/pytest --tb=auto -l /Users/jlent/dev/jl_pytest/tests/find_test_under_cursor_test.py::testPasses
INSIDE Pytest Exec: START run
INSIDE Pytest Exec: BEFORE super run
INSIDE Pytest Exec: self.proc is None
INSIDE Pytest Exec: self.proc is <Default.exec.AsyncProcess object at 0x7fdad846de10>
INSIDE Pytest Exec: AFTER super run
INSIDE Pytest Exec: START finish
Pytest Finished
FLASHING: GREEN
FLASHING: pytest_is_green
FLASHED: pytest_is_green
SET TIMEOUT: pytest_is_green
INSIDE Pytest Exec: FINISH finish
INSIDE Pytest Exec: FINISH run
```

I went through several iterations of "print debugging" before discovering the locus of the issue, but the above seems to indicate possible changes in `Default.exec.ExecCommand` renaming `.finish` to `.on_finished`

## Resolution

This single change is the full changeset after the SECOND commit (which undoes the print stmts):

```diff
diff --git a/pytest_exec.py b/pytest_exec.py
index ee88edd..ec9260f 100644
--- a/pytest_exec.py
+++ b/pytest_exec.py
@@ -57,8 +57,7 @@ class PytestExecCommand(exec.ExecCommand):
         from . import PyTest
         PyTest.State['pytest_view'] = self.output_view
 
-    def finish(self, proc):
-        super().finish(proc)
+    def on_finished(self, proc):
 
         view = self.output_view
         output = get_whole_text(view).strip()
```

The third commit adds a basic `.gitignore` to clean `__pycache__` out of `git status`.

## Testing

This PR  "works on my machine" as-is. I have NOT tested it on SublimeText3 (though I can in the next day or two).

Hopefully it aids in debugging the issue