### PR TITLE
Allow test discovery of classnames ending with test(s)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+.pytest_cache
+nosetests.xml
+coverage.xml
+
+# OSX metafiles
+.DS_Store

--- a/find_test.py
+++ b/find_test.py
@@ -60,7 +60,8 @@ def _find_class_ancestors(lines, indent):
             if curindent < indent:
                 clname_lower = clname.lower()
                 if (clname_lower.startswith('test') or
-                        clname_lower.endswith('test')):
+                        clname_lower.endswith('test') or
+                        clname_lower.endswith('tests')):
                     found.append(clname)
                     indent = curindent
                 else:

--- a/tests/find_test_under_cursor_test.py
+++ b/tests/find_test_under_cursor_test.py
@@ -88,6 +88,12 @@ class InstanceMethodsTest(TestBase):
     def testStubInstancesInsteadOfClasses(self):
         max = Dog()""",
         'InstanceMethodsTest::testStubInstancesInsteadOfClasses'),
+
+    ("""
+class ClassEndingWithTests(TestBase):
+    def testMethod(self):
+        pass""",
+        'ClassEndingWithTests::testMethod'),
 ])
 def testPasses(code, wanted):
     assert get_test_under_cursor(code) == wanted
@@ -109,4 +115,3 @@ class Foo:
 ])
 def testFailures(code):
     assert get_test_under_cursor(code) is None
-


### PR DESCRIPTION
Small _quid pro quo_:  Allow tooltips to light up on any of:

- TestFoo(TestCase)
- FooTest(TestCase)
- FooTests(TestCase) (trailing S on Tests, this one is new).

Also cherry picked the `.gitignore` from #29 