### PR TITLE
Fix test discovery at class level (follows #31)

### DIFF
--- a/find_test.py
+++ b/find_test.py
@@ -4,7 +4,7 @@ import re
 # DEF_MATCH can be either 'def' or defining a 'class'!
 DEF_MATCH = re.compile(r'(\s*)(?:def|async def|class)\s+(\w+)[(:)]')
 CLASS_MATCH = re.compile(r'(\s*)class\s+(\w+)[(:)]')
-NAME_MATCH = re.compile(r'^[tT]est')
+NAME_MATCH = re.compile(r'(^[tT]est|.*[tT]ests?$)')
 
 
 def get_test_under_cursor(text):

--- a/tests/find_test_under_cursor_test.py
+++ b/tests/find_test_under_cursor_test.py
@@ -84,6 +84,18 @@ class TestFoo:
 """, 'TestFoo'),
 
     ("""
+class BarTest:
+    def method(self):
+        pass
+""", 'BarTest'),
+
+    ("""
+class BazTests:
+    def method(self):
+        pass
+""", 'BazTests'),
+
+    ("""
 class InstanceMethodsTest(TestBase):
     def testStubInstancesInsteadOfClasses(self):
         max = Dog()""",


### PR DESCRIPTION
Following #31, I noticed a bug (of my own introduction):  Discovery via `get_test_under_cursor` works fine for `FooTests.test_method_1`, but not when cursor is at `FooTests` itself

This PR fixes that by adjusting `find_test.NAME_MATCH`, and adds test cases for top-level `FooTest(s)` invocations of `get_test_under_cursor`.